### PR TITLE
[TASK] Populate id in event streams

### DIFF
--- a/src/Stream/Psr7EventStream.php
+++ b/src/Stream/Psr7EventStream.php
@@ -115,6 +115,14 @@ final class Psr7EventStream implements EventStream
     }
 
     /**
+     * @return non-empty-string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
      * @throws Exception\StreamIsInactive
      */
     public function getResponse(): Message\ResponseInterface

--- a/src/Stream/SelfEmittingEventStream.php
+++ b/src/Stream/SelfEmittingEventStream.php
@@ -113,6 +113,14 @@ final class SelfEmittingEventStream implements EventStream
         return $this->active;
     }
 
+    /**
+     * @return non-empty-string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
     public static function canHandle(Message\ServerRequestInterface $request): bool
     {
         return $request->getHeader('Accept') === [self::CONTENT_TYPE];

--- a/tests/src/Stream/Psr7EventStreamTest.php
+++ b/tests/src/Stream/Psr7EventStreamTest.php
@@ -178,6 +178,12 @@ final class Psr7EventStreamTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function getIdReturnsId(): void
+    {
+        self::assertSame('foo', $this->subject->getId());
+    }
+
+    #[Framework\Attributes\Test]
     public function getResponseThrowsExceptionIfStreamIsNotActive(): void
     {
         $this->expectExceptionObject(new Src\Exception\StreamIsInactive());

--- a/tests/src/Stream/SelfEmittingEventStreamTest.php
+++ b/tests/src/Stream/SelfEmittingEventStreamTest.php
@@ -191,6 +191,12 @@ final class SelfEmittingEventStreamTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function getIdReturnsId(): void
+    {
+        self::assertSame('foo', $this->subject->getId());
+    }
+
+    #[Framework\Attributes\Test]
     public function canHandleReturnsTrueIfRequestAcceptsRequiredContentType(): void
     {
         $request = new Psr7\ServerRequest('GET', 'https://www.example.com');


### PR DESCRIPTION
This PR adds a new method `getId()` to both event streams. With these methods in place, event streams now populate the internal stream id.