### PR TITLE
[TASK] Force PHP 8.1 during Rector migrations

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -23,10 +23,11 @@ declare(strict_types=1);
 
 use EliasHaeussler\RectorConfig\Config\Config;
 use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    Config::create($rectorConfig)
+    Config::create($rectorConfig, PhpVersion::PHP_81)
         ->in(
             __DIR__.'/src',
             __DIR__.'/tests',


### PR DESCRIPTION
This PR explicitly configures PHP 8.1 as PHP version used for Rector migrations.